### PR TITLE
dynamic-import extra brackets

### DIFF
--- a/docs/guides/dynamic-import.md
+++ b/docs/guides/dynamic-import.md
@@ -18,7 +18,7 @@ const createBanner = (Animation) => {
   const banner = new Banner(config);
 
   banner.init().then(() => {
-      banner.setAnimation(new Animation.default((document.querySelector('.banner'), config)));
+      banner.setAnimation(new Animation.default(document.querySelector('.banner'), config));
       banner.start()
     }
   )


### PR DESCRIPTION
There were extra brackets in the parameters of the `new Animation.default()`, making a problem in the `Animation.js` when we want to use the config.